### PR TITLE
Manual Featured Content on Homepage

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -26,19 +26,23 @@ Template Name: Homepage
 
       <h2>Recent News and Upcoming Events</h2>
 
-      <?php
+      <div class="items">
 
-      $featured = get_field('featured_content');
+        <?php
 
-      if ( $featured ) {
-        foreach ( $featured as $post):
-          setup_postdata($post);
-          get_template_part('partials/article-sm');
-        endforeach;
-        wp_reset_postdata();
-      }
+        $featured = get_field('featured_content');
 
-      ?>
+        if ( $featured ) {
+          foreach ( $featured as $post):
+            setup_postdata($post);
+            get_template_part('partials/article-sm');
+          endforeach;
+          wp_reset_postdata();
+        }
+
+        ?>
+
+      </div>
 
     </section>
 

--- a/front-page.php
+++ b/front-page.php
@@ -27,11 +27,17 @@ Template Name: Homepage
       <h2>Recent News and Upcoming Events</h2>
 
       <?php
-      $loop = new WP_Query( array( 'posts_per_page'=>4, 'post_type'=>array('post','events') ) );
-      while ($loop->have_posts()) :
-        $loop->the_post();
-        get_template_part('partials/article-sm');
-      endwhile; wp_reset_postdata();
+
+      $featured = get_field('featured_content');
+
+      if ( $featured ) {
+        foreach ( $featured as $post):
+          setup_postdata($post);
+          get_template_part('partials/article-sm');
+        endforeach;
+        wp_reset_postdata();
+      }
+
       ?>
 
     </section>

--- a/library/sass/_grid.scss
+++ b/library/sass/_grid.scss
@@ -109,10 +109,13 @@ LARGE AND UP
 		}
 	}
 
-	section.articles {
-		@include clearfix;
+	section.articles .items {
+		display: flex;
+		justify-content: center;
 		article {
-			@include grid-column(3);
+			margin-left: $padding/2;
+			margin-right: $padding/2;
+			max-width: 40rem;
 		}
 	}
 


### PR DESCRIPTION
- allow Featured Content / "Recent News and Upcoming Events" section of homepage to be manually curated, using custom field in admin
- use flexbox for layout of this area, to allow flexibility for varying number of items

here's what the admin side looks like:

![screen shot 2018-10-11 at 2 39 50 pm](https://user-images.githubusercontent.com/5122304/46828879-3be6a980-cd6a-11e8-98c2-24767298a4ad.png)
