### PR TITLE
Add a function to switch GA accounts

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -145,6 +145,28 @@ function ppsri_theme_support() {
     
 } /* end ppsri theme support */
 
+// Switching GA tracking codes based on the site
+function ppsri_GA_snippet($current_id) {
+  if ( $current_id == 1) {
+    // This is the main PPS site
+    $GA_UA = 'UA-3259148-1';
+  }
+  if ( $current_id == 2) {
+    // This is the PPS DB site
+    $GA_UA = 'UA-3259148-5';
+  }
+  return "<script async src=\"https://www.googletagmanager.com/gtag/js?id=".$GA_UA."\"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '".$GA_UA."');
+  </script>";
+}
+add_action( 'init', 'ppsri_GA_snippet' );
+add_action( 'wp', 'ppsri_GA_snippet' );
+
 
 /*********************
 MENUS & NAVIGATION

--- a/functions.php
+++ b/functions.php
@@ -155,13 +155,13 @@ function ppsri_GA_snippet($current_id) {
     // This is the PPS DB site
     $GA_UA = 'UA-3259148-5';
   }
-  return "<script async src=\"https://www.googletagmanager.com/gtag/js?id=".$GA_UA."\"></script>
+  return "<script async src=\"https://www.googletagmanager.com/gtag/js?id=" . $GA_UA . "\"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
 
-    gtag('config', '".$GA_UA."');
+    gtag('config', '" . $GA_UA . "');
   </script>";
 }
 add_action( 'init', 'ppsri_GA_snippet' );

--- a/header.php
+++ b/header.php
@@ -36,10 +36,13 @@
   <meta name="msapplication-TileImage" content="<?php echo get_template_directory_uri() ?>/library/icons/mstile-144x144.png">
   <meta name="msapplication-config" content="<?php echo get_template_directory_uri() ?>/library/icons/browserconfig.xml">
   <meta name="theme-color" content="#d1dcf2">
-
-<?php if ( ! is_user_logged_in() ) { ?>
-  <?php ppsri_GA_snippet( get_current_blog_id() ); ?>
-<?php } ?>
+  <?php
+    if ( ! is_user_logged_in() ) {
+      echo ppsri_GA_snippet( get_current_blog_id() );
+    } else {
+      echo '<!-- GA code suppressed for logged in users -->';
+    }
+  ?>
 
 </head>
 

--- a/header.php
+++ b/header.php
@@ -38,16 +38,9 @@
   <meta name="theme-color" content="#d1dcf2">
 
 <?php if ( ! is_user_logged_in() ) { ?>
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-3259148-1"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-  
-    gtag('config', 'UA-3259148-1');
-  </script>
+  <?php ppsri_GA_snippet( get_current_blog_id() ); ?>
 <?php } ?>
+
 </head>
 
 <body <?php body_class(); ?>>


### PR DESCRIPTION
Instead of two different header files, as both sites use the same one, a new function checks the current multi-site blog ID and spits out a GA tracking code with the proper UA number.

Blog ID numbers taken from the Network Admin Sites Dashboard